### PR TITLE
feat/grayscale ui api hardening

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -702,8 +702,10 @@ async function sendViaDiscord({ name, email, subject, message, userHeuristics, c
       console.warn('contact: webhook rejected (status ' + status + ')')
       return false
     }
-    // Other errors
-    return false
+      // Other errors
+      const responseText = await response.text();
+      console.warn(`contact: webhook error (status ${status}): ${responseText}`);
+      return false
 
   } catch (error) {
     console.error('contact: discord exception', error?.message || error)

--- a/api/usage.js
+++ b/api/usage.js
@@ -40,9 +40,9 @@ export default async function handler(req, res) {
     // Opportunistic cleanup of stale sessions
     {
       const now = Date.now()
-      for (const [sid, sdata] of sessionEvents.entries()) {
-        if (now - (sdata.lastActivity || now) > SESSION_TIMEOUT) sessionEvents.delete(sid)
-      }
+        for (const [sid, sdata] of sessionEvents.entries()) {
+          if (now - (sdata.lastActivity ?? sdata.firstActivity ?? 0) > SESSION_TIMEOUT) sessionEvents.delete(sid)
+        }
     }
 
     // Initialize session if it doesn't exist

--- a/vercel.json
+++ b/vercel.json
@@ -9,10 +9,6 @@
   },
   "rewrites": [
     {
-      "source": "/api/(.*)",
-      "destination": "/api/$1"
-    },
-    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- remove redundant Vercel rewrite
- ensure session timeout uses first activity instead of current time
- log unhandled Discord webhook errors for contact form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9c9d23b4c8324a7e4ba65e15bf6ed